### PR TITLE
Update update.bat to use relative paths

### DIFF
--- a/ctt-update.bat
+++ b/ctt-update.bat
@@ -1,2 +1,2 @@
-COPY "C:\Program Files (x86)\Steam\steamapps\workshop\content\784150\2072854744\ctt\research" "C:\Program Files (x86)\Steam\steamapps\common\SovietRepublic\media_soviet\research"
-ECHO Community tech tree - 0.2.0 copied
+COPY "..\..\workshop\content\784150\2072854744\ctt\research" "media_soviet\research"
+ECHO Community tech tree - 0.2.1 copied


### PR DESCRIPTION
Users were reporting a problem that was caused by script relying on
absolute paths and game being installed on disk `C:`. The update changes
the script so it uses relative paths, which should solve the problem.